### PR TITLE
Correct typos on chapter references

### DIFF
--- a/04/azure_cli_sample.sh
+++ b/04/azure_cli_sample.sh
@@ -3,7 +3,7 @@
 # This script sample is part of "Learn Azure in a Month of Lunches - 2nd edition" (Manning
 # Publications) by Iain Foulds.
 #
-# This sample script covers the exercises from chapter 2 of the book. For more
+# This sample script covers the exercises from chapter 4 of the book. For more
 # information and context to these commands, read a sample of the book and
 # purchase at https://www.manning.com/books/learn-azure-in-a-month-of-lunches-second-edition
 #

--- a/19/azure_cli_sample.sh
+++ b/19/azure_cli_sample.sh
@@ -3,7 +3,7 @@
 # This script sample is part of "Learn Azure in a Month of Lunches - 2nd edition" (Manning
 # Publications) by Iain Foulds.
 #
-# This sample script covers the exercises from chapter 15 of the book. For more
+# This sample script covers the exercises from chapter 19 of the book. For more
 # information and context to these commands, read a sample of the book and
 # purchase at https://www.manning.com/books/learn-azure-in-a-month-of-lunches-second-edition
 #


### PR DESCRIPTION
I was going through your example scripts and it looks like there are two scripts that have the incorrect chapter reference. This PR makes a suggestion for what I thought these should be. Thank you for the book - it has been very helpful so far!